### PR TITLE
Naive fix for unknown hook 'pytest_warning_captured'

### DIFF
--- a/app/pytest_buildkite/__init__.py
+++ b/app/pytest_buildkite/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
     "pytest_configure",
     "pytest_sessionfinish",
     "pytest_terminal_summary",
-    "pytest_warning_captured",
+    "pytest_warning_recorded",
 ]
 
 DEFAULT_PATH = "test-output.xml"
@@ -87,7 +87,7 @@ def pytest_terminal_summary(terminalreporter):
             )
 
 
-def pytest_warning_captured(  # pylint: disable=unused-argument
+def pytest_warning_recorded(  # pylint: disable=unused-argument
     warning_message, when, *args
 ):
     """


### PR DESCRIPTION
Should fix https://github.com/pytest-buildkite/pytest-buildkite/issues/30 https://docs.pytest.org/en/stable/changelog.html#breaking-changes

<!--
Thank you for your contribution to the pytest-buildkite repository.
Your code will need to pass the automated checks before merging.
Before submitting this PR, please make sure the follow checks are done if
applicable, also if they are applicable move them out of this comment into the
main PR text body:
- [x] Unit tests added
- [x] Documentations updated with the change
- [x] Towncrier news fragment added
-->
